### PR TITLE
Add dmd v2.063

### DIFF
--- a/share/d-build/2.063
+++ b/share/d-build/2.063
@@ -1,0 +1,1 @@
+install_dmd_package "2.063" "http://downloads.dlang.org.s3-website-us-east-1.amazonaws.com/releases/2013/dmd.2.063.zip"


### PR DESCRIPTION
Which domain should we download dmd from, ftp.digitalmars.com or downloads.dlang.org.s3-website-us-east-1.amazonaws.com?
