### PR TITLE
Add ldc support

### DIFF
--- a/libexec/denv-install
+++ b/libexec/denv-install
@@ -51,6 +51,22 @@ fetch_zip() {
   } || return 1
 }
 
+fetch_tar_xz() {
+  local package_name="$1"
+  local package_url="$2"
+  local package_filename="${package_name}.tar.xz"
+
+  rm -rf "$package_filename"
+  echo "Downloading ${package_name}..." >&2
+  { http get "$package_url" > "$package_filename"
+  } || return 1
+
+  {
+    tar xf "$package_filename" > /dev/null
+    rm -f "$package_filename"
+  } || return 1
+}
+
 install_dmd_package() {
     local package_name="$1"
     local package_url="$2"
@@ -64,8 +80,33 @@ install_dmd_package() {
     mv "$package_name" "$PREFIX"
 }
 
+install_ldc_package() {
+    local package_name="$1"
+    local package_url="$2"
+    local package_path="$PREFIX/ldc-$package_name"
+    local arch_bin=""
+
+    fetch_tar_xz "$package_name" "$package_url"
+    rm -rf "$package_path"
+
+    if [ "$os" = "osx" ]; then
+        arch_bin="bin"
+    elif [ "$os" = "linux" ]; then
+        if [ "$arch" = "x86_64" ]; then
+            arch_bin="bin64"
+        else
+            arch_bin="bin32"
+        fi
+    fi
+    echo "Installing ${package_name} to ${package_path}"
+    mv "ldc2-${package_name}-${os}-${arch}" "ldc-$package_name"
+    mv "ldc-$package_name" "$PREFIX"
+    mkdir -p "$package_path/$os"
+    ln -s "$package_path/bin" "$package_path/$os/${arch_bin}"
+}
+
 # TODO: build from source
-# TODO: support gdc and ldc
+# TODO: support gdc
 
 usage() {
   # We can remove the sed fallback once rbenv 0.4.0 is widely available.
@@ -111,6 +152,24 @@ elif [ ! -e "$DEFINITION" ]; then
     echo "denv install: definition not found: ${DEFINITION}" >&2
     exit 1
   fi
+fi
+
+# for ldc
+os=""
+arch=""
+if [ `uname` = "Darwin" ]; then
+  os="osx"
+  arch="x86_64"
+elif [ `uname` = "Linux" ]; then
+  os="linux"
+  if [ `uname -m` = "x86_64" ]; then
+    arch="x86_64"
+  else
+    arch="x86"
+  fi
+else
+  echo "denv: unsupported env: `uname`"
+  exit 1
 fi
 
 for script in $(denv-hooks install); do

--- a/share/d-build/ldc-0.15.1
+++ b/share/d-build/ldc-0.15.1
@@ -1,0 +1,1 @@
+install_ldc_package "0.15.1" "https://github.com/ldc-developers/ldc/releases/download/v0.15.1/ldc2-0.15.1-$os-$arch.tar.xz"


### PR DESCRIPTION
This request enables denv to support [LDC](https://github.com/ldc-developers/ldc).
Here is the released binary: https://github.com/ldc-developers/ldc/releases
The latest release is ldc 0.15.1.

- LDC provides binaries in tar.gz and tar.xz formats.
  This request is to support tar.xz because it is much smaller than tar.gz (see `fetch_tar_xz`).
- I put a file named `ldc-0.15.1` in shared/d-build instead of `0.15.1` to distinguish LDC and DMD.
  But its file name is not consistent with other definition files for DMD releases. I think DMD definition files should have a prefix like `dmd-`.
- DMD provides only one zip file for all platforms but LDC provides different tar.xz files for each OS and archtecture.
  I introduced `$os` and `$arch` variables for LDC definition files to support different OSes and architectures.

RFC: LDC provides `ldmd2` to support the same API as `dmd`. It will be convenient if we can use DMD and LDC by using the same command name. Can I make a link from `ldmd2` to `dmd` for LDC?

I only tested it in Linux 64bit machine but I guess it will work for other platforms.