### PR TITLE
Fix denv whence and which

### DIFF
--- a/libexec/denv-whence
+++ b/libexec/denv-whence
@@ -18,7 +18,7 @@ fi
 whence() {
   local command="$1"
   denv-versions --bare | while read version; do
-    path="$(denv-prefix "$version")/bin/${command}"
+    path="$(denv-prefix "$version")/$DENV_BIN_PATH_WITH_ENV/${command}"
     if [ -x "$path" ]; then
       [ "$print_paths" ] && echo "$path" || echo "$version"
     fi

--- a/libexec/denv-which
+++ b/libexec/denv-which
@@ -73,7 +73,7 @@ else
   versions="$(denv-whence "$DENV_COMMAND" || true)"
   if [ -n "$versions" ]; then
     { echo
-      echo "The \`$1' command exists in these Ruby versions:"
+      echo "The \`$1' command exists in these D versions:"
       echo "$versions" | sed 's/^/  /g'
       echo
     } >&2


### PR DESCRIPTION
`denv which dmd` does not work correctly when we use `ldc-0.15.1`.

Expected:
```
$ denv which dmd
denv: dmd: command not found

The `dmd' command exists in these D versions:
  2.058
  2.060
  ...
```

Actual:
```
$ denv which dmd
denv: dmd: command not found
```

It is because `denv whence` uses a wrong paths for binaries.
This request fixes this issue.

