### PR TITLE
Output denv version for 0.1.2

### DIFF
--- a/libexec/denv
+++ b/libexec/denv
@@ -73,7 +73,7 @@ shopt -u nullglob
 command="$1"
 case "$command" in
 "" | "-h" | "--help" )
-  echo -e "denv 0.1.1\n$(denv-help)" >&2
+  echo -e "denv 0.1.2\n$(denv-help)" >&2
   ;;
 * )
   command_path="$(command -v "denv-$command" || true)"


### PR DESCRIPTION
README.md says that the latest version is 0.1.2 but the output of `denv` says:

```
$ denv                                                                                                                              fix-denv-version
denv 0.1.1
usage: denv <command> [<args>]
...
```

This request fixes this issue.