### PR TITLE
Make PREFIX directory for denv-install

### DIFF
--- a/libexec/denv-install
+++ b/libexec/denv-install
@@ -72,8 +72,9 @@ install_dmd_package() {
     local package_url="$2"
     local package_path="$PREFIX/$package_name"
 
-    fetch_zip "$package_name" "$package_url"    
+    fetch_zip "$package_name" "$package_url"
     rm -rf "$package_path"
+    mkdir -p "$PREFIX"
 
     echo "Installing ${package_name} to ${package_path}"
     mv dmd2 "$package_name"
@@ -88,6 +89,7 @@ install_ldc_package() {
 
     fetch_tar_xz "$package_name" "$package_url"
     rm -rf "$package_path"
+    mkdir -p "$PREFIX"
 
     if [ "$os" = "osx" ]; then
         arch_bin="bin"


### PR DESCRIPTION
First execution of `denv install` installs the compiler into the wrong directory because there are no `versions` directory at the first time.
This request fixes this issue by making `versions` directory in `denv install`.
 
How to reproduce:

1. Install denv according to the manual and install D compiler using `denv install`:
```
$ cd
$ git clone https://github.com/repeatedly/denv.git denv
...
$ export PATH=$HOME/.denv/bin:$PATH
$ denv install 2.068.1
Downloading 2.068.1...
2015-09-25 13:33:39 URL:http://downloads.dlang.org/releases/2015/dmd.2.068.1.zip [61245349/61245349] -> "-" [1]
Installing 2.068.1 to /Users/tom-tan/.denv/versions/2.068.1
```

2. See `versions` directory

Actual: 
```
$ ls .denv/versions
README.TXT  freebsd/  html/  license.txt  linux/  man/  osx/  samples/  solaris/  src/  windows/
```

But we expect:
```
$ ls .denv/versions
2.068.1/
```
