### PR TITLE
Add LDC 0.16.0

### DIFF
--- a/share/d-build/ldc-0.16.0
+++ b/share/d-build/ldc-0.16.0
@@ -1,0 +1,1 @@
+install_ldc_package "0.16.0" "https://github.com/ldc-developers/ldc/releases/download/v0.16.0/ldc2-0.16.0-$os-$arch.tar.xz"


### PR DESCRIPTION
LDC 0.16.0 is released!
It is based on 2.067.1 frontend.

Link: https://github.com/ldc-developers/ldc/releases/tag/v0.16.0