### PR TITLE
Add dmd-2.071.0 for MacOSX and Linux systems

### DIFF
--- a/share/d-build/dmd-2.071.0
+++ b/share/d-build/dmd-2.071.0
@@ -1,0 +1,1 @@
+install_dmd_package "2.071.0" "http://downloads.dlang.org/releases/2.x/2.071.0/dmd.2.071.0.$os.zip"


### PR DESCRIPTION
It fixes Issue #24 for MacOS and Linux systems.
I leave the case for FreeBSD because I do not know a good way to handle a different name convention for FreeBSD (such as `dmd2.071.0.freebsd-32.zip`).
